### PR TITLE
Updated color generator

### DIFF
--- a/src/lib/mooncat-parser.colors.test.ts
+++ b/src/lib/mooncat-parser.colors.test.ts
@@ -37,7 +37,7 @@ describe('colors', () => {
       htmlEthspresso += `Fee rate ${(feeRate + '').padStart(3, ' ')} / ${ x.toFixed(3) }: `
         + `<span style="color:${colors[1]}">${colors[1]}</span> `
         + `<span style="color:${colors[2]}">${colors[2]}</span> `
-        + `<span style="color:${colors[3]}">${colors[3]}</span> `
+        + `<span style="color:${colors[3]};font-weight:bold;">${colors[3]}</span> `
         + `<span style="color:${colors[4]}">${colors[4]}</span> `
         + `<span style="color:${colors[5]}">${colors[5]}</span>\n`
     }
@@ -59,11 +59,11 @@ describe('colors', () => {
       colors = derivePalette(rgb[0], rgb[1], rgb[2]);
 
       html2 += `Fee rate ${(feeRate + '').padStart(3, ' ')} / ${ x.toFixed(3) }: `
-      + `<span style="color:${colors[1]};font-weight:bold;">${colors[1]}</span> `
-      + `<span style="color:${colors[2]};font-weight:bold;">${colors[2]}</span> `
-      + `<span style="color:${colors[3]};font-weight:bold;">${colors[3]}</span> `
-      + `<span style="color:${colors[4]};font-weight:bold;">${colors[4]}</span> `
-      + `<span style="color:${colors[5]};font-weight:bold;">${colors[5]}</span>\n`
+      + `<span style="color:${colors[1]}">${colors[1]}</span> `
+      + `<span style="color:${colors[2]}">${colors[2]}</span> `
+      + `<span style="color:${colors[3]}">${colors[3]}</span> `
+      + `<span style="color:${colors[4]}">${colors[4]}</span> `
+      + `<span style="color:${colors[5]}">${colors[5]}</span>\n`
     }
 
 

--- a/src/lib/mooncat-parser.helper.test.ts
+++ b/src/lib/mooncat-parser.helper.test.ts
@@ -1,0 +1,23 @@
+import { map } from "./mooncat-parser.helper";
+
+describe('map', () => {
+  it('should map a number in the range', () => {
+    const res = map(5, 0, 10, 0, 100);
+    expect (res).toEqual(50);
+  });
+
+  it('should map a number outside the range', () => {
+    const res = map(50, 0, 10, 0, 100);
+    expect (res).toEqual(500);
+  });
+
+  it('should map floats', () => {
+    const res = map(0.555, 0, 1, 0, 100);
+    expect (res).toBeCloseTo(55.5);
+  });
+
+  it('should map negative numbers', () => {
+    const res = map(-20, -100, 100, 0, 1);
+    expect (res).toBeCloseTo(0.4);
+  });
+});

--- a/src/lib/mooncat-parser.helper.ts
+++ b/src/lib/mooncat-parser.helper.ts
@@ -120,9 +120,10 @@ export function RGBToHex(arr: [number, number, number]): string {
  * @param r - Red component.
  * @param g - Green component.
  * @param b - Blue component.
+ * @param s - Saturation from 0 to 1 (default 1)
  * @returns An array of hex color strings.
  */
-export function derivePalette(r: number, g: number, b: number): (string | null)[] {
+export function derivePalette(r: number, g: number, b: number, s: number = 1): (string | null)[] {
   var hsl = RGBToHSL(r, g, b);
 
   var h = hsl[0];
@@ -131,11 +132,11 @@ export function derivePalette(r: number, g: number, b: number): (string | null)[
   var hx = h % 360;
   var hy = (h + 320) % 360;
 
-  var c1 = HSLToRGB(hx, 1, 0.1);
-  var c2 = HSLToRGB(hx, 1, 0.2);
-  var c3 = HSLToRGB(hx, 1, 0.45);
-  var c4 = HSLToRGB(hx, 1, 0.7);
-  var c5 = HSLToRGB(hy, 1, 0.8);
+  var c1 = HSLToRGB(hx, s, 0.1);
+  var c2 = HSLToRGB(hx, s, 0.2);
+  var c3 = HSLToRGB(hx, s, 0.45);
+  var c4 = HSLToRGB(hx, s, 0.7);
+  var c5 = HSLToRGB(hy, s, 0.8);
 
   return [
     null,

--- a/src/lib/mooncat-parser.helper.ts
+++ b/src/lib/mooncat-parser.helper.ts
@@ -172,3 +172,16 @@ export function deriveDarkPalette(r: number, g: number, b: number): string[] {
     RGBToHex(c4)
   ];
 }
+
+/**
+ * Map a number from one range to another. Heavily inspired by p5.js map() at https://p5js.org/reference/#/p5/map
+ * @param n - Number to map
+ * @param from1 - Start of range for n
+ * @param to1 - End of range for n
+ * @param from2 - Start of destination range for result
+ * @param to2 - End of destination range for result
+ * @returns The number mapped to the destination range
+ */
+export function map(n: number, from1: number, to1: number, from2: number, to2: number): number {
+  return (n - from1) / (to1 - from1) * (to2 - from2) + from2;
+}

--- a/src/lib/mooncat-parser.ts
+++ b/src/lib/mooncat-parser.ts
@@ -8,7 +8,7 @@ import {
 } from './mooncat-parser.backgrounds';
 import { generativeColorPalette } from './mooncat-parser.colors';
 import { designs } from './mooncat-parser.designs';
-import { deriveDarkPalette, derivePalette } from './mooncat-parser.helper';
+import { map, deriveDarkPalette, derivePalette } from './mooncat-parser.helper';
 import { applyCrown, applyLaserEyes, applyLaserEyesSunglasses, applyLaserEyesSunglasses2, applySunglasses, applySunglasses2, decodeTraits } from './mooncat-parser.traits';
 
 /* *********************************************
@@ -162,24 +162,19 @@ export class MooncatParser {
       feeRate / 300,
       [0.5, 0.5, 0.5],
       [-0.9, 0.6, 0.4],
-      [2.0, 1.0, 1.0],
+      [2.5, 2.5, 2.5],
       [0.0, 0.0, 0.0]
     );
-    // Fees below 150 get a palette ranging from green to red to light blue
-    // Fees above 150 get a palette that is a mix of red, blue and purple
-    if (feeRate < 150) {
-      colors = derivePalette(
-        rgb[0],
-        rgb[1],
-        0
-      );
+
+    const saturation = map(feeRate % 40, 0, 39, 0.6, 1.0);
+    if (feeRate < 75) {
+      rgb[0] += 0.4;
+      rgb[2] = 0;
     } else {
-      colors = derivePalette(
-        rgb[0],
-        0,
-        rgb[2]
-      );
+      rgb[1] = 0;
     }
+    colors = derivePalette(rgb[0], rgb[1], rgb[2], saturation);
+
 
     if (genesis) {
 


### PR DESCRIPTION
Add variable saturation that starts at 0.6 gradually increases to 1, before restarting at 0.6 again every 40 vSat/B.

Tweak generative color palette arguments to produce less green at the start and move faster to orange-red.

Change cutoff from 150 to 75 vSat/B for oscillating red-purple-blue colors. Might work more on that part later.